### PR TITLE
Fixed mnemonicToSeedHex and CryptoJS dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function mnemonicToSeed(mnemonic, numIterations) {
 
 function mnemonicToSeedHex(mnemonic, numIterations) {
   var seed = mnemonicToSeed(mnemonic, numIterations)
-  return seed.toString('hex')
+  return seed.toString()
 }
 
 function mnemonicToEntropy(mnemonic, wordlist) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "create-hash": "^1.1.0",
-    "react-native-aes-crypto": "^1.2.1",
+    "crypto-js": "^3.1.9-1",
     "react-native-randombytes": "^2.2.0",
     "tslint": "^5.9.1",
     "unorm": "^1.3.3"


### PR DESCRIPTION
Fixed mnemonicToSeed error to compatibility with latest CryptoJS.

> TypeError: (encoder || Hex).stringify is not a function